### PR TITLE
Sync wrapper for BlockingPermitFuture

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ script:
   - 'cargo test --no-default-features --features tokio-oneshot'
   - 'cargo test --no-default-features --features tokio-threaded,tokio-oneshot'
   - 'cargo test --no-default-features --features tokio-semaphore,tokio-oneshot'
-  - 'cargo test --no-default-features --features tokio-threaded,tokio-oneshot,tokio-semaphore'
+  - 'cargo test --no-default-features --features tokio-omnibus'
   - 'cargo test --features futures-intrusive'
   - 'cargo test --features tokio-threaded,futures-intrusive'
   - 'cargo test --all-features'

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,8 @@ before_cache:
   - rm -rf /home/travis/.cargo/registry
 
 env: # important!
+  global: RUSTFLAGS=-Dwarnings
+
 matrix:
   include:
     - rust: 1.39.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,11 @@ script:
   - 'cargo test'
   - 'cargo test --features current-thread'
   - 'cargo test --no-default-features --features tokio-oneshot'
+  - 'cargo test --no-default-features --features tokio-threaded,tokio-oneshot'
+  - 'cargo test --no-default-features --features tokio-semaphore,tokio-oneshot
+  - 'cargo test --no-default-features --features tokio-threaded,tokio-oneshot,tokio-semaphore'
+  - 'cargo test --features futures-intrusive'
+  - 'cargo test --features tokio-threaded,futures-intrusive'
   - 'cargo test --all-features'
   - 'if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then cargo build --all-features --all-targets; fi'
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ script:
   - 'cargo test --features current-thread'
   - 'cargo test --no-default-features --features tokio-oneshot'
   - 'cargo test --no-default-features --features tokio-threaded,tokio-oneshot'
-  - 'cargo test --no-default-features --features tokio-semaphore,tokio-oneshot
+  - 'cargo test --no-default-features --features tokio-semaphore,tokio-oneshot'
   - 'cargo test --no-default-features --features tokio-threaded,tokio-oneshot,tokio-semaphore'
   - 'cargo test --features futures-intrusive'
   - 'cargo test --features tokio-threaded,futures-intrusive'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,7 +31,7 @@ dependencies = [
 
 [[package]]
 name = "bytes"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -394,7 +394,7 @@ name = "tokio"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bytes 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "pin-project-lite 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -432,7 +432,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [metadata]
 "checksum autocfg 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "1d49d90015b3c36167a20fe2810c5cd875ad504b39cff3d4eae7977e6b7c1cb2"
 "checksum bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
-"checksum bytes 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1c85319f157e4e26c703678e68e26ab71a46c0199286fa670b21cc9fec13d895"
+"checksum bytes 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "10004c15deb332055f7a4a208190aed362cf9a7c2f6ab70a305fba50e1105f38"
 "checksum c2-chacha 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "214238caa1bf3a496ec3392968969cab8549f96ff30652c9e56885329315f6bb"
 "checksum cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,7 +26,7 @@ dependencies = [
  "num_cpus 1.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -161,7 +161,7 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.3"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -203,7 +203,7 @@ name = "num_cpus"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "hermit-abi 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hermit-abi 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -391,7 +391,7 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "0.2.4"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -448,7 +448,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum futures-task 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0bae52d6b29cf440e298856fec3965ee6fa71b06aa7495178615953fd669e5f9"
 "checksum futures-util 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c0d66274fb76985d3c62c886d1da7ac4c0903a8c9f754e8fe0f35a6a6cc39e76"
 "checksum getrandom 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "e7db7ca94ed4cd01190ceee0d8a8052f08a247aa1b469a7f68c6a3b71afcf407"
-"checksum hermit-abi 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "307c3c9f937f38e3534b1d6447ecf090cafcc9744e4a6360e8b037b2cf5af120"
+"checksum hermit-abi 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "f629dc602392d3ec14bfc8a09b5e644d7ffd725102b48b81e59f90f2633621d7"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 "checksum libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)" = "d515b1f41455adea1313a4a2ac8a8a477634fbae63cc6100e3aebb207ce61558"
 "checksum lock_api 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e57b3997725d2b60dbec1297f6c2e2957cc383db1cebd6be812163f969c7d586"
@@ -478,7 +478,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum smallvec 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)" = "f7b0758c52e15a8b5e3691eae6cc559f08eee9406e548a4477ba4e67770a82b6"
 "checksum syn 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)" = "dff0acdb207ae2fe6d5976617f887eb1e35a2ba52c13c7234c790960cdad9238"
 "checksum tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
-"checksum tokio 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "bcced6bb623d4bff3739c176c415f13c418f426395c169c9c3cd9a492c715b16"
+"checksum tokio 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0e1bef565a52394086ecac0a6fa3b8ace4cb3a138ee1d96bd2b93283b56824e3"
 "checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
 "checksum wasi 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b89c3ce4ce14bdc6fb6beaf9ec7928ca331de5df7e5ea278375642a2f478570d"
 "checksum winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ lazy_static         = { version=">= 1.3.0, <1.5" }
 log                 = { version=">=0.4.4, <0.5" }
 crossbeam-channel   = { version=">=0.4.0, <0.5" }
 num_cpus            = { version=">=1.11.1, <1.12" }
-futures-intrusive   = { version=">=0.2.2, <0.3" }
+futures-intrusive   = { version=">=0.2.2, <0.3", optional=true }
 tokio               = { version=">=0.2.2, <0.3", optional=true }
 
 [dev-dependencies]
@@ -37,6 +37,9 @@ tokio-oneshot=[
 ]
 tokio-threaded=[
     "tokio", "tokio/rt-core", "tokio/rt-threaded", "tokio/blocking"
+]
+tokio-semaphore=[
+    "tokio", "tokio/sync"
 ]
 current-thread=[] # testing hack
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,6 @@ build         = "build.rs"
 [dependencies]
 futures-core        = { version=">=0.3.1, <0.4" }
 futures-channel     = { version=">=0.3.1, <0.4", optional=true }
-lazy_static         = { version=">= 1.3.0, <1.5" }
 log                 = { version=">=0.4.4, <0.5" }
 crossbeam-channel   = { version=">=0.4.0, <0.5" }
 num_cpus            = { version=">=1.11.1, <1.12" }
@@ -25,10 +24,11 @@ tokio               = { version=">=0.2.2, <0.3", optional=true }
 
 [dev-dependencies]
 env_logger          = { version=">=0.7.1, <0.8", default-features=false }
-tempfile            = { version=">=3.1.0, <3.2" }
-rand                = { version=">=0.7.0, <0.8" }
 futures-executor    = { version=">=0.3.1, <0.4" }
 futures-util        = { version=">=0.3.1, <0.4" }
+lazy_static         = { version=">=1.3.0, <1.5" }
+rand                = { version=">=0.7.0, <0.8" }
+tempfile            = { version=">=3.1.0, <3.2" }
 
 [features]
 default=["futures-channel"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,17 +31,23 @@ rand                = { version=">=0.7.0, <0.8" }
 tempfile            = { version=">=3.1.0, <3.2" }
 
 [features]
+# Need some oneshot channel for dispatch_rx, default to futures
+# Use default-features=false in combination with tokio-oneshot, if desired.
 default=["futures-channel"]
-tokio-oneshot=[
-    "tokio", "tokio/sync"
-]
-tokio-threaded=[
-    "tokio", "tokio/rt-core", "tokio/rt-threaded", "tokio/blocking"
-]
-tokio-semaphore=[
-    "tokio", "tokio/sync"
-]
-current-thread=[] # testing hack
+
+# All available tokio integrations
+tokio-omnibus=["tokio-oneshot", "tokio-threaded", "tokio-semaphore"]
+
+# Instead of (default) futures-channel oneshot
+tokio-oneshot=["tokio", "tokio/sync"]
+
+# Tokio threaded runtime, including blocking support
+tokio-threaded=["tokio", "tokio/rt-core", "tokio/rt-threaded", "tokio/blocking"]
+
+# Instead of futures-intrusive semaphore. (Both are optional)
+tokio-semaphore=["tokio", "tokio/sync"]
+
+current-thread=[] # testing hack only
 
 [profile.bench]
 lto = "thin"

--- a/benches/dispatch.rs
+++ b/benches/dispatch.rs
@@ -115,6 +115,7 @@ fn noop_threaded_in_place(b: &mut Bencher) {
         let futures: FuturesUnordered<_> = (0..100).map(|_| {
             rt.spawn(async {
                 let p = blocking_permit_future(&DEFAULT_SET)
+                    .make_sync()
                     .await
                     .unwrap();
                 let r = p.run(|| 41);
@@ -246,6 +247,7 @@ fn r_expensive_threaded_in_place(b: &mut Bencher) {
         let futures: FuturesUnordered<_> = (0..100).map(|_| {
             rt.spawn(async {
                 let p = blocking_permit_future(&DEFAULT_SET)
+                    .make_sync()
                     .await
                     .unwrap();
                 let r = p.run(|| expensive_comp());
@@ -372,6 +374,7 @@ fn sleep_threaded_in_place(b: &mut Bencher) {
         let futures: FuturesUnordered<_> = (0..100).map(|_| {
             rt.spawn(async {
                 let p = blocking_permit_future(&SLEEP_SET)
+                    .make_sync()
                     .await
                     .unwrap();
                 let r = p.run(|| random_sleep());

--- a/benches/dispatch.rs
+++ b/benches/dispatch.rs
@@ -22,6 +22,13 @@ use blocking_permit::{
     Semaphore
 };
 
+#[cfg(feature = "tokio-semaphore")]
+lazy_static! {
+    static ref TEST_SET: Semaphore = Semaphore::new(20);
+}
+
+#[cfg(not(feature = "tokio-semaphore"))]
+#[cfg(feature = "futures-intrusive")]
 lazy_static! {
     static ref TEST_SET: Semaphore = Semaphore::new(true, 20);
 }
@@ -34,7 +41,8 @@ fn noop_threaded_dispatch_rx(b: &mut Bencher) {
         .create();
 
     let mut rt = tokio::runtime::Builder::new()
-        .num_threads(4)
+        .core_threads(4)
+        .max_threads(4+2)
         .threaded_scheduler()
         .on_thread_start(move || {
             register_dispatch_pool(pool.clone());
@@ -70,7 +78,8 @@ fn noop_threaded_dispatch_rx(b: &mut Bencher) {
 #[bench]
 fn noop_threaded_spawn_blocking(b: &mut Bencher) {
     let mut rt = tokio::runtime::Builder::new()
-        .num_threads(4)
+        .core_threads(4)
+        .max_threads(4+2)
         .threaded_scheduler()
         .build()
         .unwrap();
@@ -100,7 +109,8 @@ fn noop_threaded_spawn_blocking(b: &mut Bencher) {
 #[bench]
 fn noop_threaded_in_place(b: &mut Bencher) {
     let mut rt = tokio::runtime::Builder::new()
-        .num_threads(4)
+        .core_threads(4)
+        .max_threads(4+2)
         .threaded_scheduler()
         .build()
         .unwrap();
@@ -157,7 +167,8 @@ fn r_expensive_threaded_dispatch_rx(b: &mut Bencher) {
         .create();
 
     let mut rt = tokio::runtime::Builder::new()
-        .num_threads(4)
+        .core_threads(4)
+        .max_threads(4+2)
         .threaded_scheduler()
         .on_thread_start(move || {
             register_dispatch_pool(pool.clone());
@@ -198,7 +209,8 @@ fn r_expensive_threaded_dispatch_rx(b: &mut Bencher) {
 #[bench]
 fn r_expensive_threaded_spawn_blocking(b: &mut Bencher) {
     let mut rt = tokio::runtime::Builder::new()
-        .num_threads(4)
+        .core_threads(4)
+        .max_threads(4+2)
         .threaded_scheduler()
         .build()
         .unwrap();
@@ -228,7 +240,8 @@ fn r_expensive_threaded_spawn_blocking(b: &mut Bencher) {
 #[bench]
 fn r_expensive_threaded_in_place(b: &mut Bencher) {
     let mut rt = tokio::runtime::Builder::new()
-        .num_threads(4)
+        .core_threads(4)
+        .max_threads(4+2)
         .threaded_scheduler()
         .build()
         .unwrap();
@@ -285,7 +298,8 @@ fn sleep_threaded_dispatch_rx(b: &mut Bencher) {
         .create();
 
     let mut rt = tokio::runtime::Builder::new()
-        .num_threads(4)
+        .core_threads(4)
+        .max_threads(4+2)
         .threaded_scheduler()
         .on_thread_start(move || {
             register_dispatch_pool(pool.clone());
@@ -321,7 +335,8 @@ fn sleep_threaded_dispatch_rx(b: &mut Bencher) {
 #[bench]
 fn sleep_threaded_spawn_blocking(b: &mut Bencher) {
     let mut rt = tokio::runtime::Builder::new()
-        .num_threads(4)
+        .core_threads(4)
+        .max_threads(4+2)
         .threaded_scheduler()
         .build()
         .unwrap();
@@ -351,7 +366,8 @@ fn sleep_threaded_spawn_blocking(b: &mut Bencher) {
 #[bench]
 fn sleep_threaded_in_place(b: &mut Bencher) {
     let mut rt = tokio::runtime::Builder::new()
-        .num_threads(20)
+        .core_threads(20)
+        .max_threads(20+2)
         .threaded_scheduler()
         .build()
         .unwrap();

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -1,4 +1,5 @@
-// TODO: This is currently just a subset of potential usage from tokio_fs
+// TODO: This is currently just a subset of potential usage from tokio_fs,
+// retained for testing.
 
 use std::fs;
 use std::io;
@@ -6,17 +7,10 @@ use std::path::Path;
 
 use lazy_static::lazy_static;
 
-use crate::{dispatch_or_permit, Semaphore};
+use crate::{dispatch_or_permit, Semaphore, Semaphorish};
 
-#[cfg(feature = "tokio-semaphore")]
 lazy_static! {
-    static ref BLOCKING_SET: Semaphore = Semaphore::new(1);
-}
-
-#[cfg(not(feature = "tokio-semaphore"))]
-#[cfg(feature = "futures-intrusive")]
-lazy_static! {
-    static ref BLOCKING_SET: Semaphore = Semaphore::new(true, 1);
+    static ref BLOCKING_SET: Semaphore = Semaphore::default_new(1);
 }
 
 /// Creates a new, empty directory at the provided path

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -8,8 +8,15 @@ use lazy_static::lazy_static;
 
 use crate::{dispatch_or_permit, Semaphore};
 
+#[cfg(feature = "tokio-semaphore")]
 lazy_static! {
-    pub static ref BLOCKING_SET: Semaphore = Semaphore::new(true, 1);
+    static ref BLOCKING_SET: Semaphore = Semaphore::new(1);
+}
+
+#[cfg(not(feature = "tokio-semaphore"))]
+#[cfg(feature = "futures-intrusive")]
+lazy_static! {
+    static ref BLOCKING_SET: Semaphore = Semaphore::new(true, 1);
 }
 
 /// Creates a new, empty directory at the provided path
@@ -71,7 +78,8 @@ mod tests {
 
         {
             let mut rt = tokio::runtime::Builder::new()
-                .num_threads(2)
+                .core_threads(2)
+                .max_threads(2)
                 .threaded_scheduler()
                 .build()
                 .unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,6 +36,7 @@ pub use permit::{
     blocking_permit_future,
     BlockingPermit,
     BlockingPermitFuture,
+    SyncBlockingPermitFuture,
 };
 
 /// An async-aware semaphore for constraining the number of concurrent blocking

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,6 +41,7 @@ pub use permit::{
     BlockingPermit,
     BlockingPermitFuture,
     Semaphore,
+    Semaphorish,
     SyncBlockingPermitFuture,
 };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,8 +14,11 @@
 mod dispatch;
 mod dispatch_pool;
 mod errors;
+
+#[cfg(any(feature = "tokio-semaphore", feature = "futures-intrusive"))]
 mod permit;
 
+#[cfg(any(feature = "tokio-semaphore", feature = "futures-intrusive"))]
 #[macro_use] mod macros;
 
 pub use dispatch::{
@@ -32,20 +35,18 @@ pub use dispatch_pool::{DispatchPool, DispatchPoolBuilder};
 
 pub use errors::Canceled;
 
+#[cfg(any(feature = "tokio-semaphore", feature = "futures-intrusive"))]
 pub use permit::{
     blocking_permit_future,
     BlockingPermit,
     BlockingPermitFuture,
+    Semaphore,
     SyncBlockingPermitFuture,
 };
-
-/// An async-aware semaphore for constraining the number of concurrent blocking
-/// operations.
-///
-pub use futures_intrusive::sync::Semaphore;
 
 #[cfg(test)]
 mod tests;
 
+#[cfg(any(feature = "tokio-semaphore", feature = "futures-intrusive"))]
 #[cfg(test)]
 mod fs;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -27,13 +27,7 @@
             }
             $crate::DispatchRx::NotRegistered(cl) => {
                 let permit = $crate::blocking_permit_future($semaphore) .await?;
-                #[cfg(not(feature="tokio-threaded"))] {
-                    permit.enter();
-                    cl()
-                }
-                #[cfg(feature="tokio-threaded")] {
-                    permit.run(cl)
-                }
+                permit.run(cl)
             }
         }
     }};

--- a/src/permit.rs
+++ b/src/permit.rs
@@ -15,14 +15,11 @@ pub use tokio_semaphore::{
     blocking_permit_future,
     BlockingPermit,
     BlockingPermitFuture,
+    Semaphore
 };
 
-/// An async-aware semaphore for constraining the number of concurrent blocking
-/// operations.
-#[cfg(feature = "tokio-semaphore")]
-pub use tokio::sync::Semaphore;
-
 #[cfg(not(feature = "tokio-semaphore"))]
+#[cfg(feature = "futures-intrusive")]
 mod intrusive;
 
 #[cfg(not(feature = "tokio-semaphore"))]
@@ -31,13 +28,13 @@ pub use intrusive::{
     blocking_permit_future,
     BlockingPermit,
     BlockingPermitFuture,
+    Semaphore
 };
 
-/// An async-aware semaphore for constraining the number of concurrent blocking
-/// operations.
-#[cfg(not(feature = "tokio-semaphore"))]
-#[cfg(feature = "futures-intrusive")]
-pub use futures_intrusive::sync::Semaphore;
+pub trait Semaphorish {
+    /// Construct given number of permits. Choose _fair_ if that is an option.
+    fn default_new(permits: usize) -> Self;
+}
 
 // Note: these methods are common to both above struct definitions
 

--- a/src/permit.rs
+++ b/src/permit.rs
@@ -27,6 +27,7 @@ pub struct BlockingPermitFuture<'a> {
     semaphore: &'a Semaphore,
     acquire: Option<SemaphoreAcquireFuture<'a>>
 }
+
 impl<'a> BlockingPermitFuture<'a> {
     /// Construct given `Semaphore` reference.
     pub fn new(semaphore: &Semaphore) -> BlockingPermitFuture<'_>

--- a/src/permit.rs
+++ b/src/permit.rs
@@ -28,6 +28,15 @@ pub struct BlockingPermitFuture<'a> {
     acquire: Option<SemaphoreAcquireFuture<'a>>
 }
 impl<'a> BlockingPermitFuture<'a> {
+    /// Construct given `Semaphore` reference.
+    pub fn new(semaphore: &Semaphore) -> BlockingPermitFuture<'_>
+    {
+        BlockingPermitFuture {
+            semaphore,
+            acquire: None
+        }
+    }
+
     /// Make a `Sync` version of this future by wrapping with a `Mutex`.
     pub fn make_sync(self) -> SyncBlockingPermitFuture<'a> {
         SyncBlockingPermitFuture {
@@ -80,6 +89,16 @@ impl<'a> FusedFuture for BlockingPermitFuture<'a> {
 #[derive(Debug)]
 pub struct SyncBlockingPermitFuture<'a> {
     futr: Mutex<BlockingPermitFuture<'a>>
+}
+
+impl<'a> SyncBlockingPermitFuture<'a> {
+    /// Construct given `Semaphore` reference.
+    pub fn new(semaphore: &'a Semaphore) -> SyncBlockingPermitFuture<'a>
+    {
+        SyncBlockingPermitFuture {
+            futr: Mutex::new(BlockingPermitFuture::new(semaphore))
+        }
+    }
 }
 
 impl<'a> Future for SyncBlockingPermitFuture<'a> {

--- a/src/permit.rs
+++ b/src/permit.rs
@@ -5,7 +5,6 @@ mod tokio_semaphore;
 
 #[cfg(feature = "tokio-semaphore")]
 pub use tokio_semaphore::{
-    blocking_permit_future,
     BlockingPermit,
     BlockingPermitFuture,
     Semaphore,
@@ -19,7 +18,6 @@ mod intrusive;
 #[cfg(not(feature = "tokio-semaphore"))]
 #[cfg(feature = "futures-intrusive")]
 pub use intrusive::{
-    blocking_permit_future,
     BlockingPermit,
     BlockingPermitFuture,
     Semaphore,
@@ -87,4 +85,18 @@ impl<'a> Drop for BlockingPermit<'a> {
             warn!("Dropped BlockingPermit (semaphore) was never entered")
         }
     }
+}
+
+/// Request a permit to perform a blocking operation on the current thread.
+///
+/// The returned future attempts to obtain a permit from the provided
+/// `Semaphore` and outputs a `BlockingPermit` which can then be
+/// [`run`](BlockingPermit::run) to allow blocking or "long running"
+/// operation, while the `BlockingPermit` remains in scope. If no permits are
+/// immediately available, then the current task context will be notified when
+/// one becomes available.
+pub fn blocking_permit_future(semaphore: &Semaphore)
+    -> BlockingPermitFuture<'_>
+{
+    BlockingPermitFuture::new(semaphore)
 }

--- a/src/permit.rs
+++ b/src/permit.rs
@@ -88,8 +88,7 @@ impl<'a> Future for SyncBlockingPermitFuture<'a> {
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>)
         -> Poll<Self::Output>
     {
-        let this = unsafe { self.get_unchecked_mut() };
-        match this.futr.try_lock() {
+        match self.futr.try_lock() {
             Ok(mut guard) => {
                 let futr = unsafe { Pin::new_unchecked(&mut *guard) };
                 futr.poll(cx)

--- a/src/permit/intrusive.rs
+++ b/src/permit/intrusive.rs
@@ -6,7 +6,11 @@ use std::task::{Context, Poll};
 use futures_core::future::FusedFuture;
 use futures_intrusive::sync::{SemaphoreAcquireFuture, SemaphoreReleaser};
 
-use crate::{Canceled, Semaphore};
+/// An async-aware semaphore for constraining the number of concurrent blocking
+/// operations.
+pub use futures_intrusive::sync::Semaphore;
+
+use crate::{Canceled, Semaphorish};
 
 /// A scoped permit for blocking operations. When dropped (out of scope or
 /// manually), the permit is released.
@@ -24,6 +28,12 @@ pub struct BlockingPermit<'a> {
 pub struct BlockingPermitFuture<'a> {
     semaphore: &'a Semaphore,
     acquire: Option<SemaphoreAcquireFuture<'a>>
+}
+
+impl Semaphorish for Semaphore {
+    fn default_new(permits: usize) -> Self {
+        Semaphore::new(true, permits)
+    }
 }
 
 impl<'a> BlockingPermitFuture<'a> {

--- a/src/permit/intrusive.rs
+++ b/src/permit/intrusive.rs
@@ -1,0 +1,91 @@
+use std::cell::Cell;
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use futures_core::future::FusedFuture;
+use futures_intrusive::sync::{SemaphoreAcquireFuture, SemaphoreReleaser};
+
+use crate::{Canceled, Semaphore};
+
+/// A scoped permit for blocking operations. When dropped (out of scope or
+/// manually), the permit is released.
+#[must_use = "must call `run` or `enter` before blocking"]
+#[derive(Debug)]
+pub struct BlockingPermit<'a> {
+    releaser: SemaphoreReleaser<'a>,
+    pub(crate) entered: Cell<bool>
+}
+
+/// A future which resolves to a [`BlockingPermit`], created via the
+/// [`blocking_permit_future`] function.
+#[must_use = "must be `.await`ed or polled"]
+#[derive(Debug)]
+pub struct BlockingPermitFuture<'a> {
+    semaphore: &'a Semaphore,
+    acquire: Option<SemaphoreAcquireFuture<'a>>
+}
+
+impl<'a> BlockingPermitFuture<'a> {
+    /// Construct given `Semaphore` reference.
+    pub fn new(semaphore: &Semaphore) -> BlockingPermitFuture<'_>
+    {
+        BlockingPermitFuture {
+            semaphore,
+            acquire: None
+        }
+    }
+}
+
+impl<'a> Future for BlockingPermitFuture<'a> {
+    type Output = Result<BlockingPermit<'a>, Canceled>;
+
+    // Note that with this implementation, `Canceled` is never returned. For
+    // maximum future flexibilty however (like reverting to tokio's Semaphore)
+    // we keep the error type in place.
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>)
+        -> Poll<Self::Output>
+    {
+        // Safety: FIXME
+        let this = unsafe { self.get_unchecked_mut() };
+        let acq = if let Some(ref mut af) = this.acquire {
+            af
+        } else {
+            this.acquire = Some(this.semaphore.acquire(1));
+            this.acquire.as_mut().unwrap()
+        };
+        let acq = unsafe { Pin::new_unchecked(acq) };
+        match acq.poll(cx) {
+            Poll::Pending => Poll::Pending,
+            Poll::Ready(releaser) => Poll::Ready(Ok(BlockingPermit {
+                releaser,
+                entered: Cell::new(false)
+            })),
+       }
+    }
+}
+
+impl<'a> FusedFuture for BlockingPermitFuture<'a> {
+    fn is_terminated(&self) -> bool {
+        if let Some(ref ff) = self.acquire {
+            ff.is_terminated()
+        } else {
+            false
+        }
+    }
+}
+
+/// Request a permit to perform a blocking operation on the current thread.
+///
+/// The returned future attempts to obtain a permit from the provided
+/// `Semaphore` and outputs a `BlockingPermit` which can then be
+/// [`run`](BlockingPermit::run) to allow blocking or "long running"
+/// operation, while the `BlockingPermit` remains in scope. If no permits are
+/// immediately available, then the current task context will be notified when
+/// one becomes available.
+pub fn blocking_permit_future(semaphore: &Semaphore)
+    -> BlockingPermitFuture<'_>
+{
+    BlockingPermitFuture::new(semaphore)
+}

--- a/src/permit/intrusive.rs
+++ b/src/permit/intrusive.rs
@@ -95,20 +95,6 @@ impl<'a> FusedFuture for BlockingPermitFuture<'a> {
     }
 }
 
-/// Request a permit to perform a blocking operation on the current thread.
-///
-/// The returned future attempts to obtain a permit from the provided
-/// `Semaphore` and outputs a `BlockingPermit` which can then be
-/// [`run`](BlockingPermit::run) to allow blocking or "long running"
-/// operation, while the `BlockingPermit` remains in scope. If no permits are
-/// immediately available, then the current task context will be notified when
-/// one becomes available.
-pub fn blocking_permit_future(semaphore: &Semaphore)
-    -> BlockingPermitFuture<'_>
-{
-    BlockingPermitFuture::new(semaphore)
-}
-
 /// A `Sync` wrapper available via [`BlockingPermitFuture::make_sync`].
 #[must_use = "must be `.await`ed or polled"]
 #[derive(Debug)]

--- a/src/permit/tokio_semaphore.rs
+++ b/src/permit/tokio_semaphore.rs
@@ -105,17 +105,3 @@ impl<'a> Future for BlockingPermitFuture<'a> {
         }
     }
 }
-
-/// Request a permit to perform a blocking operation on the current thread.
-///
-/// The returned future attempts to obtain a permit from the provided
-/// `Semaphore` and outputs a `BlockingPermit` which can then be
-/// [`run`](BlockingPermit::run) to allow blocking or "long running" operation,
-/// while the `BlockingPermit` remains in scope. If no permits are immediately
-/// available, then the current task context will be notified when one becomes
-/// available.
-pub fn blocking_permit_future(semaphore: &Semaphore)
-    -> BlockingPermitFuture<'_>
-{
-    BlockingPermitFuture::new(semaphore)
-}

--- a/src/permit/tokio_semaphore.rs
+++ b/src/permit/tokio_semaphore.rs
@@ -6,9 +6,13 @@ use std::task::{Context, Poll};
 
 use log::debug;
 
-use tokio::sync::{SemaphorePermit, Semaphore};
+use tokio::sync::SemaphorePermit;
 
-use crate::Canceled;
+/// An async-aware semaphore for constraining the number of concurrent blocking
+/// operations.
+pub use tokio::sync::Semaphore;
+
+use crate::{Canceled, Semaphorish};
 
 /// A scoped permit for blocking operations. When dropped (out of scope or
 /// manually), the permit is released.
@@ -29,6 +33,12 @@ pub struct BlockingPermitFuture<'a> {
     semaphore: &'a Semaphore,
     permit: Option<Box<dyn Future<Output=SemaphorePermit<'a>> + Send + 'a>>,
     acquired: bool,
+}
+
+impl Semaphorish for Semaphore {
+    fn default_new(permits: usize) -> Self {
+        Semaphore::new(permits)
+    }
 }
 
 impl<'a> BlockingPermitFuture<'a> {

--- a/src/permit/tokio_semaphore.rs
+++ b/src/permit/tokio_semaphore.rs
@@ -57,7 +57,9 @@ impl<'a> BlockingPermitFuture<'a> {
     }
 
     /// Ensure a `Sync` version of this future.
-    pub fn make_sync(self) -> SyncBlockingPermitFuture<'a> {
+    pub fn make_sync(self) -> SyncBlockingPermitFuture<'a>
+        where Self: Sync
+    {
         self
     }
 

--- a/src/permit/tokio_semaphore.rs
+++ b/src/permit/tokio_semaphore.rs
@@ -1,0 +1,100 @@
+use std::cell::Cell;
+use std::fmt;
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use log::debug;
+
+use tokio::sync::{SemaphorePermit, Semaphore};
+
+use crate::Canceled;
+
+/// A scoped permit for blocking operations. When dropped (out of scope or
+/// manually), the permit is released.
+///
+/// Note that [`enter`](BlockingPermit::enter) must be called before the actual
+/// blocking begins.
+#[must_use = "must call `run` or `enter` before blocking"]
+#[derive(Debug)]
+pub struct BlockingPermit<'a> {
+    permit: SemaphorePermit<'a>,
+    pub(crate) entered: Cell<bool>
+}
+
+/// A future which resolves to a [`BlockingPermit`], created via the
+/// [`blocking_permit_future`] function.
+#[must_use = "must be `.await`ed or polled"]
+pub struct BlockingPermitFuture<'a> {
+    semaphore: &'a Semaphore,
+    permit: Option<Box<dyn Future<Output=SemaphorePermit<'a>> + Send + 'a>>,
+    acquired: bool,
+}
+
+impl<'a> BlockingPermitFuture<'a> {
+
+    /// Construct given `Semaphore` reference.
+    pub fn new(semaphore: &'a Semaphore) -> BlockingPermitFuture<'a>
+    {
+        BlockingPermitFuture {
+            semaphore,
+            permit: None,
+            acquired: false,
+        }
+    }
+}
+
+impl<'a> fmt::Debug for BlockingPermitFuture<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("BlockingPermitFuture")
+            .field("semaphore", self.semaphore)
+            .field("permit", &self.permit.is_some())
+            .field("acquired", &self.acquired)
+            .finish()
+    }
+}
+
+impl<'a> Future for BlockingPermitFuture<'a> {
+    type Output = Result<BlockingPermit<'a>, Canceled>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>)
+        -> Poll<Self::Output>
+    {
+        if self.acquired {
+            panic!("BlockingPermitFuture::poll called again after acquired");
+        }
+
+        let mut permit = self.permit.take()
+            .unwrap_or_else(|| Box::new(self.semaphore.acquire()));
+
+        let ppin = unsafe { Pin::new_unchecked(&mut *permit) };
+        match ppin.poll(cx) {
+            Poll::Ready(sp) => {
+                debug!("Creating BlockingPermit (semaphore)");
+                self.acquired = true;
+                Poll::Ready(Ok(BlockingPermit {
+                    permit: sp,
+                    entered: Cell::new(false)
+                }))
+            }
+            Poll::Pending => {
+                self.permit = Some(permit);
+                Poll::Pending
+            }
+        }
+    }
+}
+
+/// Request a permit to perform a blocking operation on the current thread.
+///
+/// The returned future attempts to obtain a permit from the provided
+/// `Semaphore` and outputs a `BlockingPermit` which can then be
+/// [`run`](BlockingPermit::run) to allow blocking or "long running" operation,
+/// while the `BlockingPermit` remains in scope. If no permits are immediately
+/// available, then the current task context will be notified when one becomes
+/// available.
+pub fn blocking_permit_future(semaphore: &Semaphore)
+    -> BlockingPermitFuture<'_>
+{
+    BlockingPermitFuture::new(semaphore)
+}

--- a/src/permit/tokio_semaphore.rs
+++ b/src/permit/tokio_semaphore.rs
@@ -56,7 +56,7 @@ impl<'a> BlockingPermitFuture<'a> {
         }
     }
 
-    /// Make a `Sync` version of this future by wrapping with a `Mutex`.
+    /// Ensure a `Sync` version of this future.
     pub fn make_sync(self) -> SyncBlockingPermitFuture<'a> {
         self
     }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -24,15 +24,21 @@ lazy_static! {
 
 fn is_send<T: Send>() -> bool { true }
 
-#[allow(dead_code)]
-fn is_unwind_safe<T: UnwindSafe>() -> bool { true }
+#[allow(dead_code)] fn is_sync<T: Sync>() -> bool { true }
+
+#[allow(dead_code)] fn is_unwind_safe<T: UnwindSafe>() -> bool { true }
 
 #[test]
 fn test_blocking_permit_traits() {
     assert!(is_send::<BlockingPermit<'_>>());
+    // TODO: its not: assert!(is_sync::<BlockingPermit<'_>>());
 
     // TODO: its not UnwindSafe because internals are not.  Does it need to be?
     // assert!(is_unwind_safe::<BlockingPermit<'_>>());
+
+    assert!(is_send::<BlockingPermitFuture<'_>>());
+    // TODO: its not: assert!(is_sync::<BlockingPermitFuture<'_>>());
+
 }
 
 fn log_init() {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -28,15 +28,9 @@ use log::info;
 
 use crate::*;
 
-#[cfg(feature = "tokio-semaphore")]
+#[cfg(any(feature = "tokio-semaphore", feature = "futures-intrusive"))]
 lazy_static! {
-    static ref TEST_SET: Semaphore = Semaphore::new(1);
-}
-
-#[cfg(not(feature = "tokio-semaphore"))]
-#[cfg(feature = "futures-intrusive")]
-lazy_static! {
-    static ref TEST_SET: Semaphore = Semaphore::new(true, 1);
+    static ref TEST_SET: Semaphore = Semaphore::default_new(1);
 }
 
 #[allow(dead_code)] fn is_send<T: Send>() -> bool { true }
@@ -358,15 +352,8 @@ fn test_futr_local_pool() {
 fn test_tokio_threadpool() {
     log_init();
 
-    #[cfg(feature = "tokio-semaphore")]
     lazy_static! {
-        static ref TEST_SET: Semaphore = Semaphore::new(3);
-    }
-
-    #[cfg(not(feature = "tokio-semaphore"))]
-    #[cfg(feature = "futures-intrusive")]
-    lazy_static! {
-        static ref TEST_SET: Semaphore = Semaphore::new(true, 3);
+        static ref TEST_SET: Semaphore = Semaphore::default_new(3);
     }
 
     static FINISHED: AtomicUsize = AtomicUsize::new(0);

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -48,6 +48,10 @@ fn test_blocking_permit_traits() {
 
     assert!(is_send::<BlockingPermitFuture<'_>>());
 
+    #[cfg(features = "tokio-semaphore")] {
+        assert!(is_sync::<BlockingPermitFuture<'_>>());
+    }
+
     assert!(is_send::<SyncBlockingPermitFuture<'_>>());
     assert!(is_sync::<SyncBlockingPermitFuture<'_>>());
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -37,8 +37,9 @@ fn test_blocking_permit_traits() {
     // assert!(is_unwind_safe::<BlockingPermit<'_>>());
 
     assert!(is_send::<BlockingPermitFuture<'_>>());
-    assert!(is_sync::<SyncBlockingPermitFuture<'_>>());
 
+    assert!(is_send::<SyncBlockingPermitFuture<'_>>());
+    assert!(is_sync::<SyncBlockingPermitFuture<'_>>());
 }
 
 fn log_init() {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -23,15 +23,13 @@ lazy_static! {
 }
 
 fn is_send<T: Send>() -> bool { true }
-
-#[allow(dead_code)] fn is_sync<T: Sync>() -> bool { true }
+fn is_sync<T: Sync>() -> bool { true }
 
 #[allow(dead_code)] fn is_unwind_safe<T: UnwindSafe>() -> bool { true }
 
 #[test]
 fn test_blocking_permit_traits() {
     assert!(is_send::<BlockingPermit<'_>>());
-    // TODO: its not: assert!(is_sync::<BlockingPermit<'_>>());
 
     // TODO: its not UnwindSafe because internals are not.  Does it need to be?
     // assert!(is_unwind_safe::<BlockingPermit<'_>>());

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -37,7 +37,7 @@ fn test_blocking_permit_traits() {
     // assert!(is_unwind_safe::<BlockingPermit<'_>>());
 
     assert!(is_send::<BlockingPermitFuture<'_>>());
-    // TODO: its not: assert!(is_sync::<BlockingPermitFuture<'_>>());
+    assert!(is_sync::<SyncBlockingPermitFuture<'_>>());
 
 }
 


### PR DESCRIPTION
This gives us a `Sync` version of the `Semaphore` future in safe code.  As the Mutex should be uncontended in normal use, it should be low overhead. 