### PR TITLE
Cleaver: a Stream adapter for splitting buffers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
-/target/
+/target
+.cargo/

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ script:
   - 'cargo test --no-default-features --features tokio-threaded,tokio-oneshot'
   - 'cargo test --no-default-features --features tokio-semaphore,tokio-oneshot'
   - 'cargo test --no-default-features --features tokio-omnibus'
+  - 'cargo test --features cleaver'
   - 'cargo test --features futures-intrusive'
   - 'cargo test --features tokio-threaded,futures-intrusive'
   - 'cargo test --all-features'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "blocking-permit"
 version = "1.1.0"
 dependencies = [
+ "bytes 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-channel 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -102,9 +103,9 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro-hack 0.5.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -210,7 +211,7 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.1.2"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -228,9 +229,9 @@ name = "proc-macro-hack"
 version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -240,7 +241,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -251,7 +252,7 @@ name = "quote"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -345,10 +346,10 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -374,7 +375,7 @@ dependencies = [
  "bytes 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "pin-project-lite 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pin-project-lite 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -431,12 +432,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum num_cpus 1.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "46203554f085ff89c235cd12f7075f3233af9b11ed7c9e16dfe2560d03313ce6"
 "checksum parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f842b1982eb6c2fe34036a4fbfb06dd185a3f5c8edfaacdf7d1ea10b07de6252"
 "checksum parking_lot_core 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b876b1b9e7ac6e1a74a6da34d25c42e17e8862aa409cbbbdcfc8d86c6f3bc62b"
-"checksum pin-project-lite 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e8822eb8bb72452f038ebf6048efa02c3fe22bf83f76519c9583e47fc194a422"
+"checksum pin-project-lite 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "237844750cfbb86f67afe27eee600dfbbcb6188d734139b534cbfbf4f96792ae"
 "checksum pin-utils 0.1.0-alpha.4 (registry+https://github.com/rust-lang/crates.io-index)" = "5894c618ce612a3fa23881b152b608bafb8c56cfc22f434a3ba3120b40f7b587"
 "checksum ppv-lite86 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "74490b50b9fbe561ac330df47c08f3f33073d2d00c150f719147d7c54522fa1b"
 "checksum proc-macro-hack 0.5.11 (registry+https://github.com/rust-lang/crates.io-index)" = "ecd45702f76d6d3c75a80564378ae228a85f0b59d2f3ed43c91b4a69eb2ebfc5"
 "checksum proc-macro-nested 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "369a6ed065f249a159e06c45752c780bda2fb53c995718f9e484d08daa9eb42e"
-"checksum proc-macro2 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)" = "0319972dcae462681daf4da1adeeaa066e3ebd29c69be96c6abb1259d2ee2bcc"
+"checksum proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)" = "3acb317c6ff86a4e579dfa00fc5e6cca91ecbb4e7eb2df0468805b674eb88548"
 "checksum quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe"
 "checksum rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 "checksum rand_chacha 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "03a2a90da8c7523f554344f921aa97283eadf6ac484a6d2a7d0212fa7f8d6853"
@@ -450,7 +451,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 "checksum slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 "checksum smallvec 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)" = "f7b0758c52e15a8b5e3691eae6cc559f08eee9406e548a4477ba4e67770a82b6"
-"checksum syn 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)" = "1e4ff033220a41d1a57d8125eab57bf5263783dfdcc18688b1dacc6ce9651ef8"
+"checksum syn 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)" = "af6f3550d8dff9ef7dc34d384ac6f107e5d31c8f57d9f28e0081503f547ac8f5"
 "checksum tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
 "checksum tokio 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)" = "ffa2fdcfa937b20cb3c822a635ceecd5fc1a27a6a474527e5516aa24b8c8820a"
 "checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17,7 +17,7 @@ dependencies = [
  "futures-util 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "num_cpus 1.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 1.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -177,7 +177,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "num_cpus"
-version = "1.11.1"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "hermit-abi 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -373,7 +373,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "num_cpus 1.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 1.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pin-project-lite 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -428,7 +428,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum lock_api 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "79b2de95ecb4691949fea4716ca53cdbcfccb2c612e19644a8bad05edcf9f47b"
 "checksum log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
 "checksum maybe-uninit 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
-"checksum num_cpus 1.11.1 (registry+https://github.com/rust-lang/crates.io-index)" = "76dac5ed2a876980778b8b85f75a71b6cbf0db0b1232ee12f826bccb00d09d72"
+"checksum num_cpus 1.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "46203554f085ff89c235cd12f7075f3233af9b11ed7c9e16dfe2560d03313ce6"
 "checksum parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f842b1982eb6c2fe34036a4fbfb06dd185a3f5c8edfaacdf7d1ea10b07de6252"
 "checksum parking_lot_core 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b876b1b9e7ac6e1a74a6da34d25c42e17e8862aa409cbbbdcfc8d86c6f3bc62b"
 "checksum pin-project-lite 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e8822eb8bb72452f038ebf6048efa02c3fe22bf83f76519c9583e47fc194a422"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ exclude       = [".gitignore", ".travis.yml", "appveyor.yml"]
 build         = "build.rs"
 
 [dependencies]
+bytes               = { version=">=0.5.2, <0.6", optional=true }
 futures-core        = { version=">=0.3.1, <0.4" }
 futures-channel     = { version=">=0.3.1, <0.4", optional=true }
 log                 = { version=">=0.4.4, <0.5" }
@@ -47,6 +48,9 @@ tokio-threaded=["tokio", "tokio/rt-core", "tokio/rt-threaded", "tokio/blocking"]
 # Instead of futures-intrusive semaphore. (Both are optional)
 tokio-semaphore=["tokio", "tokio/sync"]
 
+# The `Cleaver` stream adapter
+cleaver=["bytes"]
+
 current-thread=[] # testing hack only
 
 tangential=[] # less interesting benchmarks
@@ -56,4 +60,4 @@ lto = "thin"
 incremental = false
 
 [package.metadata.docs.rs]
-features = ["futures-intrusive"]
+features = ["futures-intrusive", "cleaver"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ build         = "build.rs"
 futures-core        = { version=">=0.3.1, <0.4" }
 futures-channel     = { version=">=0.3.1, <0.4", optional=true }
 log                 = { version=">=0.4.4, <0.5" }
-num_cpus            = { version=">=1.11.1, <1.12" }
+num_cpus            = { version=">=1.11.1, <1.13" }
 futures-intrusive   = { version=">=0.2.2, <0.3", optional=true }
 tokio               = { version=">=0.2.6, <0.3", optional=true }
 parking_lot         = { version=">=0.9.0, <0.11" }

--- a/src/cleaver.rs
+++ b/src/cleaver.rs
@@ -1,0 +1,91 @@
+use std::fmt;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use bytes::Bytes;
+use futures_core::stream::Stream;
+
+/// Trait for buffer types that may be split at a maximum length.
+pub trait Splittable: Sized {
+    /// If self has length greater then the specific maximum, split it into
+    /// two, returning the new leading segment and with self mutated to
+    /// contain the remainder.
+    fn split_if(&mut self, max: usize) -> Option<Self>;
+}
+
+impl Splittable for Bytes {
+    fn split_if(&mut self, max: usize) -> Option<Self> {
+        if self.len() > max {
+            Some(self.split_to(max))
+        } else {
+            None
+        }
+    }
+}
+
+/// A `Stream` adapter that splits buffers from a source to a given, maximum
+/// length.
+pub struct Cleaver<B, E, St>
+    where B: Splittable + Unpin,
+          St: Stream<Item=Result<B, E>> + fmt::Debug
+{
+    source: St,
+    rem: Option<B>,
+    max: usize,
+}
+
+impl<B, E, St> Stream for Cleaver<B, E, St>
+    where B: Splittable + Unpin,
+          St: Stream<Item=Result<B, E>> + fmt::Debug
+{
+    type Item = Result<B, E>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>)
+        -> Poll<Option<Self::Item>>
+    {
+        let this = unsafe { self.get_unchecked_mut() };
+        match this.rem {
+            Some(ref mut b) => {
+                match b.split_if(this.max) {
+                    Some(l) => {
+                        return Poll::Ready(Some(Ok(l)))
+                    }
+                    None => {
+                        return Poll::Ready(Some(Ok(this.rem.take().unwrap())));
+                    }
+                }
+            }
+            None => {}
+        }
+        let src = unsafe { Pin::new_unchecked(&mut this.source) };
+        match src.poll_next(cx) {
+            Poll::Ready(Some(Ok(b))) => {
+                this.rem = Some(b);
+                // recurse for proper waking
+                let this = unsafe { Pin::new_unchecked(this) };
+                this.poll_next(cx)
+            }
+            other => other,
+        }
+    }
+}
+
+impl<B, E, St> fmt::Debug for Cleaver<B, E, St>
+    where B: Splittable + Unpin,
+          St: Stream<Item=Result<B, E>> + fmt::Debug
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("File")
+            .field("source", &self.source)
+            .field(
+                "rem",
+                if self.rem.is_none() {
+                    &"None"
+                } else {
+                    &"Some(...)"
+                }
+            )
+            .field("max", &self.max)
+            .finish()
+    }
+}

--- a/src/cleaver.rs
+++ b/src/cleaver.rs
@@ -34,6 +34,19 @@ pub struct Cleaver<B, E, St>
     max: usize,
 }
 
+impl<B, E, St> Cleaver<B, E, St>
+    where B: Splittable + Unpin,
+          St: Stream<Item=Result<B, E>>
+{
+    /// Construct with source and maximum size to split on.
+    ///
+    /// The size to split on must be at least 1.
+    pub fn new(source: St, max: usize) -> Self {
+        assert!(max > 0);
+        Cleaver { source, rem: None, max }
+    }
+}
+
 impl<B, E, St> Stream for Cleaver<B, E, St>
     where B: Splittable + Unpin,
           St: Stream<Item=Result<B, E>>

--- a/src/cleaver.rs
+++ b/src/cleaver.rs
@@ -13,6 +13,8 @@ pub trait Splittable: Sized {
     fn split_if(&mut self, max: usize) -> Option<Self>;
 }
 
+/// This implementation is inexpensive, relying on `Bytes::split_to` which does
+/// not copy.
 impl Splittable for Bytes {
     fn split_if(&mut self, max: usize) -> Option<Self> {
         if self.len() > max {
@@ -25,6 +27,9 @@ impl Splittable for Bytes {
 
 /// A `Stream` adapter that splits buffers from a source to a given, maximum
 /// length.
+///
+/// This may be useful to limit the amount of time spent processing each `Item`
+/// of a `Splittable` stream.
 pub struct Cleaver<B, E, St>
     where B: Splittable + Unpin,
           St: Stream<Item=Result<B, E>>

--- a/src/cleaver.rs
+++ b/src/cleaver.rs
@@ -93,7 +93,7 @@ impl<B, E, St> fmt::Debug for Cleaver<B, E, St>
           St: Stream<Item=Result<B, E>> + fmt::Debug
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("File")
+        f.debug_struct("Cleaver")
             .field("source", &self.source)
             .field(
                 "rem",

--- a/src/cleaver.rs
+++ b/src/cleaver.rs
@@ -27,7 +27,7 @@ impl Splittable for Bytes {
 /// length.
 pub struct Cleaver<B, E, St>
     where B: Splittable + Unpin,
-          St: Stream<Item=Result<B, E>> + fmt::Debug
+          St: Stream<Item=Result<B, E>>
 {
     source: St,
     rem: Option<B>,
@@ -36,7 +36,7 @@ pub struct Cleaver<B, E, St>
 
 impl<B, E, St> Stream for Cleaver<B, E, St>
     where B: Splittable + Unpin,
-          St: Stream<Item=Result<B, E>> + fmt::Debug
+          St: Stream<Item=Result<B, E>>
 {
     type Item = Result<B, E>;
 

--- a/src/cleaver.rs
+++ b/src/cleaver.rs
@@ -7,7 +7,9 @@ use futures_core::stream::Stream;
 
 /// Trait for buffer types that may be split at a maximum length.
 pub trait Splittable: Sized {
-    /// If self has length greater then the specific maximum, split it into
+    /// Split if larger then a maximum length.
+    ///
+    /// If self has length greater then the specified maximum, split it into
     /// two, returning the new leading segment and with self mutated to
     /// contain the remainder.
     fn split_if(&mut self, max: usize) -> Option<Self>;

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -84,6 +84,7 @@ impl<F, T> DispatchRx<F, T> {
 /// closure is spawned on the pool, and this returns a `Dispatched` future,
 /// which resolves to the result of the closure. Otherwise the original closure
 /// is returned.
+#[must_use = "dispatch_rx returned `Dispatch` must be `await`-ed"]
 pub fn dispatch_rx<F, T>(f: F) -> DispatchRx<F, T>
     where F: FnOnce() -> T + Send + 'static,
           T: Send + 'static

--- a/src/dispatch_pool.rs
+++ b/src/dispatch_pool.rs
@@ -342,9 +342,9 @@ impl DispatchPoolBuilder {
     /// Set whether to catch and ignore unwinds for dispatch tasks that panic,
     /// or to abort.
     ///
-    /// When true, panics are ignored. Note that the unwind safety of
-    /// dispatched tasks is not well assured by the `UnwindSafe` marker trait
-    /// and may later result in undefined behavior (UB) or logic bugs.
+    /// If true, panics are ignored. Note that the unwind safety of dispatched
+    /// tasks is not well assured by the `UnwindSafe` marker trait and may
+    /// later result in undefined behavior (UB) or logic bugs.
     ///
     /// If false, a panic in a dispatch pool thread will result in process
     /// abort.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,7 +45,10 @@ pub use permit::{
     SyncBlockingPermitFuture,
 };
 
+#[cfg(feature = "cleaver")]
 mod cleaver;
+
+#[cfg(feature = "cleaver")]
 pub use cleaver::{
     Cleaver,
     Splittable,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,6 +45,12 @@ pub use permit::{
     SyncBlockingPermitFuture,
 };
 
+mod cleaver;
+pub use cleaver::{
+    Cleaver,
+    Splittable,
+};
+
 /// An async-aware semaphore for constraining the number of concurrent blocking
 /// operations.
 ///

--- a/src/permit.rs
+++ b/src/permit.rs
@@ -99,6 +99,7 @@ impl<'a> Drop for BlockingPermit<'a> {
 /// operation, while the `BlockingPermit` remains in scope. If no permits are
 /// immediately available, then the current task context will be notified when
 /// one becomes available.
+#[must_use = "blocking_permit_future does nothing unless polled/`await`-ed"]
 pub fn blocking_permit_future(semaphore: &Semaphore)
     -> BlockingPermitFuture<'_>
 {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -464,6 +464,21 @@ fn test_cleaver_empty() {
     use futures_util::{stream, stream::StreamExt};
     use std::io;
     let task = async {
+        let bstream = stream::empty();
+        let cleaver = super::Cleaver::new(bstream, 1);
+        cleaver.collect::<Vec<Result<Bytes,io::Error>>>().await
+    };
+    let collected = futr_exec::block_on(task);
+    assert_eq!(collected.len(), 0);
+}
+
+
+#[cfg(feature="cleaver")]
+#[test]
+fn test_cleaver_empty_bytes() {
+    use futures_util::{stream, stream::StreamExt};
+    use std::io;
+    let task = async {
         let bstream = stream::once(async { Ok(Bytes::new()) });
         let cleaver = super::Cleaver::new(bstream, 1);
         cleaver.collect::<Vec<Result<Bytes,io::Error>>>().await

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -466,7 +466,7 @@ fn test_cleaver_empty() {
     let task = async {
         let bstream = stream::empty();
         let cleaver = super::Cleaver::new(bstream, 1);
-        cleaver.collect::<Vec<Result<Bytes,io::Error>>>().await
+        cleaver.collect::<Vec<Result<Bytes,io::Error>>>() .await
     };
     let collected = futr_exec::block_on(task);
     assert_eq!(collected.len(), 0);
@@ -481,7 +481,7 @@ fn test_cleaver_empty_bytes() {
     let task = async {
         let bstream = stream::once(async { Ok(Bytes::new()) });
         let cleaver = super::Cleaver::new(bstream, 1);
-        cleaver.collect::<Vec<Result<Bytes,io::Error>>>().await
+        cleaver.collect::<Vec<Result<Bytes,io::Error>>>() .await
     };
     let collected = futr_exec::block_on(task);
     assert_eq!(collected.len(), 1);
@@ -496,7 +496,7 @@ fn test_cleaver_through() {
     let task = async {
         let bstream = stream::once(async { Ok(Bytes::from("foobar")) });
         let cleaver = super::Cleaver::new(bstream, 9);
-        cleaver.collect::<Vec<Result<Bytes,io::Error>>>().await
+        cleaver.collect::<Vec<Result<Bytes,io::Error>>>() .await
     };
     let collected = futr_exec::block_on(task);
     assert_eq!(collected.len(), 1);
@@ -511,7 +511,7 @@ fn test_cleaver_more() {
     let task = async {
         let bstream = stream::once(async { Ok(Bytes::from("foobar")) });
         let cleaver = super::Cleaver::new(bstream, 4);
-        cleaver.collect::<Vec<Result<Bytes,io::Error>>>().await
+        cleaver.collect::<Vec<Result<Bytes,io::Error>>>() .await
     };
     let collected = futr_exec::block_on(task);
     assert_eq!(collected.len(), 2);


### PR DESCRIPTION
Given a maximum length and `Splittable` buffers (implemented here for `Bytes`) ensures that buffers from a source stream are split to this length if found to be larger. This *could* be useful to limit blocking/processing time, for each buffer.