### PR TITLE
Broaden tokio dependency to include new 1.1.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 1.3.1 (unreleased)
+
 ## 1.3.0 (2021-1-8)
 * Update to bytes 1.0 and tokio 1.0.1 (MSRV 1.45.2)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.3.1 (unreleased)
+## 1.3.1 (2021-1-23)
 * Broaden tokio dependency to include new 1.1.z releases.
 
 * Add previously missing LICENSE-(APACHE/MIT) files to repo and package.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
 ## 1.3.1 (unreleased)
+* Broaden tokio dependency to include new 1.1.z releases.
+
+* Add previously missing LICENSE-(APACHE/MIT) files to repo and package.
+
+* Update dev. dependencies rand (to 0.8.0) and broaden tempfile (incl. 3.2).
+
+* Add clippy config for primordial MSRV build.rs and for current MSRV.
 
 ## 1.3.0 (2021-1-8)
 * Update to bytes 1.0 and tokio 1.0.1 (MSRV 1.45.2)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -126,9 +126,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4060f4657be78b8e766215b02b18a2e862d83745545de804638e2b545e81aee6"
+checksum = "c9495705279e7140bf035dde1f6e750c162df8b625267cd52cc44e0b156732c8"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
@@ -390,9 +390,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.0.2"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ca04cec6ff2474c638057b65798f60ac183e5e79d3448bb7163d36a39cff6ec"
+checksum = "8efab2086f17abcddb8f756117665c958feee6b2e39974c2f1600592ab3a4195"
 dependencies = [
  "autocfg",
  "num_cpus",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,7 +14,7 @@ checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
 name = "blocking-permit"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "bytes",
  "futures-channel",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -365,9 +365,9 @@ checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
 
 [[package]]
 name = "syn"
-version = "1.0.58"
+version = "1.0.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc60a3d73ea6594cd712d830cc1f0390fd71542d8c8cd24e70cc54cdfd5e05d5"
+checksum = "07cb8b1b4ebf86a89ee88cbd201b022b94138c623644d035185c84d3f41b7e66"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ futures-channel     = { version=">=0.3.1, <0.4", optional=true }
 log                 = { version=">=0.4.4, <0.5" }
 num_cpus            = { version=">=1.11.1, <1.14" }
 futures-intrusive   = { version=">=0.3.1, <0.5", optional=true }
-tokio               = { version=">=1.0.1, <1.1", optional=true }
+tokio               = { version=">=1.0.1, <1.2", optional=true }
 parking_lot         = { version=">=0.10.0, <0.12" }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blocking-permit"
-version = "1.3.0"
+version = "1.3.1"
 edition = "2018"
 authors = ["David Kellum <dek-oss@gravitext.com>"]
 license       = "MIT/Apache-2.0"


### PR DESCRIPTION
tokio-rs/tokio#3462 was released

https://github.com/tokio-rs/tokio/releases/tag/tokio-1.1.0